### PR TITLE
Update arbitrum install branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "npm run test:arbitrum --network=$network",
-    "installLocalArbitrum": "git clone -b sequencer2 https://github.com/offchainlabs/arbitrum.git",
+    "installLocalArbitrum": "git clone -b master https://github.com/offchainlabs/arbitrum.git",
     "startLocalEthereum": "cd arbitrum && git submodule update --init --recursive && yarn && yarn build && yarn docker:build:geth && yarn docker:geth",
     "startLocalArbitrum": "cd arbitrum && yarn demo:initialize && yarn demo:deploy",
     "compile:ethereum": "truffle compile",


### PR DESCRIPTION
## Problem
When installing Arbitrum locally, we were previously instructed to use a particular branch.  [According to their docs](https://developer.offchainlabs.com/docs/installation#download-arbitrum), this is no longer the case.

## Solution
Update the branch used to reflect their docs.