### PR TITLE
Remove yarn build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run test:arbitrum --network=$network",
     "installLocalArbitrum": "git clone -b master https://github.com/offchainlabs/arbitrum.git",
-    "startLocalEthereum": "cd arbitrum && git submodule update --init --recursive && yarn && yarn build && yarn docker:build:geth && yarn docker:geth",
+    "startLocalEthereum": "cd arbitrum && git submodule update --init --recursive && yarn && yarn docker:build:geth && yarn docker:geth",
     "startLocalArbitrum": "cd arbitrum && yarn demo:initialize && yarn demo:deploy",
     "compile:ethereum": "truffle compile",
     "compile:arbitrum": "truffle compile --config truffle-config.arbitrum.js",


### PR DESCRIPTION
[As mentioned](https://github.com/truffle-box/arbitrum-box/issues/12#issuecomment-1181022982) in #12, the arbitrum package.json no longer contains a `yarn build` command as it was [removed](https://github.com/OffchainLabs/arbitrum/commit/7579700f562466f1297eea95b3cb63326af0913b#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20) during the deprecation of arb-ts.  The `startLocalEthereum` script functions without this step, so we can simply remove it.