### PR TITLE
Add Goerli RPC to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ If you are unfamiliar with using `.env` for managing your mnemonics and other ke
 ```
 MNEMONIC="jar deny prosper gasp flush glass core corn alarm treat leg smart"
 INFURA_KEY="<Your Infura Project ID>"
-RINKEBY_MNEMONIC="<Your Rinkeby Mnemonic>"
 GOERLI_MNEMONIC="<Your Goerli Mnemonic>"
 MAINNET_MNEMONIC="<Your Arbitrum Mainnet Mnemonic>"
 ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ If you are unfamiliar with using `.env` for managing your mnemonics and other ke
 MNEMONIC="jar deny prosper gasp flush glass core corn alarm treat leg smart"
 INFURA_KEY="<Your Infura Project ID>"
 RINKEBY_MNEMONIC="<Your Rinkeby Mnemonic>"
+GOERLI_MNEMONIC="<Your Goerli Mnemonic>"
 MAINNET_MNEMONIC="<Your Arbitrum Mainnet Mnemonic>"
 ```
 

--- a/truffle-config.arbitrum.js
+++ b/truffle-config.arbitrum.js
@@ -47,7 +47,7 @@ module.exports = {
       }
     },
     // Arbitrum Goerli is the replacement for RinkArby, a previous Arbitrum testnet.
-    // RinkArby will be deprecated when Rinkeby itself gets deprecated, so it has been removed from here.
+    // RinkArby will be deprecated when Rinkeby itself gets deprecated, so it has been removed from this configuration file.
     // More details: https://developer.offchainlabs.com/docs/Public_Chains
     arbitrum_goerli: {
       network_id: 421613,

--- a/truffle-config.arbitrum.js
+++ b/truffle-config.arbitrum.js
@@ -1,14 +1,12 @@
 // create a file at the root of your project and name it .env -- there you can set process variables
 // like the mnemomic below. Note: .env is ignored by git in this project to keep your private information safe
 require('dotenv').config();
-const mnemonic = process.env["MNEMONIC"];
+
+// Make sure you have these values set in a .env file, and add .env to your .gitignore.
 const infuraKey = process.env["INFURA_KEY"];
-
-//uncomment to use goerliMnemonic, be sure to set it in the .env file
-//const goerliMnemonic = process.env["GOERLI_MNEMONIC"];
-
-//uncomment to use mainnetMnemonic, be sure to set it in the .env file
-//const mainnetMnemonic = process.env["MAINNET_MNEMONIC"]
+const mnemonic = process.env["MNEMONIC"];
+const goerliMnemonic = process.env["GOERLI_MNEMONIC"];
+const mainnetMnemonic = process.env["MAINNET_MNEMONIC"]
 
 const HDWalletProvider = require('@truffle/hdwallet-provider');
 

--- a/truffle-config.arbitrum.js
+++ b/truffle-config.arbitrum.js
@@ -4,6 +4,12 @@ require('dotenv').config();
 const mnemonic = process.env["MNEMONIC"];
 const infuraKey = process.env["INFURA_KEY"];
 
+//uncomment to use goerliMnemonic, be sure to set it in the .env file
+//const goerliMnemonic = process.env["GOERLI_MNEMONIC"];
+
+//uncomment to use rinkebyMnemonic, be sure to set it in the .env file
+//const rinkebyMnemonic = process.env["RINKEBY_MNEMONIC"];
+
 //uncomment to use mainnetMnemonic, be sure to set it in the .env file
 //const mainnetMnemonic = process.env["MAINNET_MNEMONIC"]
 
@@ -43,12 +49,27 @@ module.exports = {
         })
       }
     },
+    arbitrum_goerli: {
+      network_id: 421613,
+      provider: function() {
+        return new HDWalletProvider({
+          mnemonic: {
+            phrase: goerliMnemonic
+          },
+          providerOrUrl: 'https://arbitrum-goerli.infura.io/v3/' + infuraKey,
+          addressIndex: 0,
+          numberOfAddresses: 1,
+          network_id: 421613,
+          chainId: 421613
+        })
+      }
+    },
     arbitrum_testnet: {
       network_id: 421611,
       provider: function() {
         return new HDWalletProvider({
           mnemonic: {
-            phrase: mnemonic
+            phrase: rinkebyMnemonic
           },
           providerOrUrl: 'https://arbitrum-rinkeby.infura.io/v3/' + infuraKey,
           addressIndex: 0,

--- a/truffle-config.arbitrum.js
+++ b/truffle-config.arbitrum.js
@@ -7,9 +7,6 @@ const infuraKey = process.env["INFURA_KEY"];
 //uncomment to use goerliMnemonic, be sure to set it in the .env file
 //const goerliMnemonic = process.env["GOERLI_MNEMONIC"];
 
-//uncomment to use rinkebyMnemonic, be sure to set it in the .env file
-//const rinkebyMnemonic = process.env["RINKEBY_MNEMONIC"];
-
 //uncomment to use mainnetMnemonic, be sure to set it in the .env file
 //const mainnetMnemonic = process.env["MAINNET_MNEMONIC"]
 
@@ -49,6 +46,9 @@ module.exports = {
         })
       }
     },
+    // Arbitrum Goerli is the replacement for RinkArby, a previous Arbitrum testnet.
+    // RinkArby will be deprecated when Rinkeby itself gets deprecated, so it has been removed from here.
+    // More details: https://developer.offchainlabs.com/docs/Public_Chains
     arbitrum_goerli: {
       network_id: 421613,
       provider: function() {
@@ -61,21 +61,6 @@ module.exports = {
           numberOfAddresses: 1,
           network_id: 421613,
           chainId: 421613
-        })
-      }
-    },
-    arbitrum_testnet: {
-      network_id: 421611,
-      provider: function() {
-        return new HDWalletProvider({
-          mnemonic: {
-            phrase: rinkebyMnemonic
-          },
-          providerOrUrl: 'https://arbitrum-rinkeby.infura.io/v3/' + infuraKey,
-          addressIndex: 0,
-          numberOfAddresses: 1,
-          network_id: 421611,
-          chainId: 421611
         })
       }
     },


### PR DESCRIPTION
Arbitrum Nitro now exists on Goerli testnet: https://developer.offchainlabs.com/docs/Public_Chains

This adds the config settings for the Goerli Arbitrum and removes Rinkeby Arbitrum. From [their docs](https://developer.offchainlabs.com/docs/Public_Chains)

> RinkArby is the longest running Arbitrum testnet. It previously ran on the classic stack, but at block 7/28/2022 it was migrated use the Nitro stack! Rinkarby will be deprecated [when Rinkeby itself gets deprecated](https://blog.ethereum.org/2022/06/21/testnet-deprecation/); plan accordingly!